### PR TITLE
migrate to avalanche 1.3

### DIFF
--- a/avax-cli.sh
+++ b/avax-cli.sh
@@ -81,7 +81,7 @@ case "$1" in
         case $2 in 
         get)
             ava_pod=$(kubectl get pods -n "$ava_namespace" | grep ava-node | awk '{print $1}')
-            kubectl exec -it "$ava_pod" -n "$ava_namespace" -- tar cfz /tmp/staking.tgz -C /root/.avalanchego staking
+            kubectl exec -it "$ava_pod" -n "$ava_namespace" -- tar cfz /tmp/staking.tgz -C /root/staking-keys staking
             kubectl cp "$ava_pod":/tmp/staking.tgz $3 -n "$ava_namespace"
             kubectl exec -it "$ava_pod" -n "$ava_namespace" -- rm /tmp/staking.tgz
         ;;

--- a/kube-avax-values.yaml
+++ b/kube-avax-values.yaml
@@ -6,7 +6,7 @@ image:
   pullPolicy: IfNotPresent
   # avalanchego tag from docker hub
   # https://hub.docker.com/r/avaplatform/avalanchego/tags?page=1&ordering=last_updated
-  tag: "v1.2.0"
+  tag: "v1.3.1"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -15,7 +15,7 @@ fullnameOverride: ""
 avalancheNode:
   containerPort: 9651
   command: '["/avalanchego/build/avalanchego"]'
-  args: '["--dynamic-public-ip=opendns","--http-host=","--log-level=info"]'
+  args: '["--dynamic-public-ip=opendns","--http-host=","--log-level=info","--staking-tls-key-file=/root/staking-keys/staking/staker.key","--staking-tls-cert-file=/root/staking-keys/staking/staker.crt"]'
 
 # Persistent volume claim size
 storage: "250Gi"

--- a/kube-avax/templates/avalanchenode.yaml
+++ b/kube-avax/templates/avalanchenode.yaml
@@ -47,7 +47,7 @@ spec:
               mountPath: /root/.avalanchego
             {{- if .Values.stakingKey }}
             - name: {{ .Values.stakingKey }}
-              mountPath: /root/.avalanchego/staking
+              mountPath: /root/staking-keys/staking
               readOnly: true
             {{- end }}
           # /ext/health endpoint returns success after


### PR DESCRIPTION
- [x] migrate to avalanche 1.3.1
- [x] 1.3 introduced breaking change such that read-only staking folder cannot longer be inside default directory which is .avalanche. Moved it to /root/staking-keys instead